### PR TITLE
Scrolling graph

### DIFF
--- a/ner_processing/decode_data.py
+++ b/ner_processing/decode_data.py
@@ -310,7 +310,3 @@ def decodeLoggingStatus(data: List[int]) -> Dict[int, Any]:
     return {
         129: data[0]
     }
-def decodeLoggingStatus(data: List[int]) -> Dict[int, Any]:
-    return {
-        114: data[0]
-    }

--- a/ner_processing/decode_data.py
+++ b/ner_processing/decode_data.py
@@ -310,3 +310,7 @@ def decodeLoggingStatus(data: List[int]) -> Dict[int, Any]:
     return {
         129: data[0]
     }
+def decodeLoggingStatus(data: List[int]) -> Dict[int, Any]:
+    return {
+        114: data[0]
+    }

--- a/ner_telhub/view/vehicle/window.py
+++ b/ner_telhub/view/vehicle/window.py
@@ -260,6 +260,7 @@ class VehicleWindow(QMainWindow):
         super().__init__(parent)
 
         self.data_model = DataModelManager(self)
+        self.data_model.setDataLimiting(True)
         self.message_model = MessageModel(self, self.data_model)
         self.receive_filter_model = ReceiveFilterModel(
             self, self.message_model)

--- a/ner_telhub/widgets/graphing_widgets.py
+++ b/ner_telhub/widgets/graphing_widgets.py
@@ -276,12 +276,6 @@ class GraphWidget(QWidget):
 
         # Specific config for real time graphs
         if dynamic:
-            refresh_button = NERImageButton(
-                NERImageButton.Icons.REFRESH, NERButton.Styles.GRAY)
-            refresh_button.pressed.connect(self.updateChart)
-            refresh_button.setToolTip("Refresh the live data")
-            toolbar.addRight(refresh_button)
-
             self.timer = QTimer()
             self.timer.timeout.connect(self.updateChart)
             self.timer.start()


### PR DESCRIPTION
Only allows the graph to display 50 datapoints when graphing live data, removes the oldest points when exceeding 50 data points in the model manager. The number of data points can be changed by an environment variable.

#Closes 101